### PR TITLE
Only reset the port if it wasn't set in the request

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -812,7 +812,7 @@ Client.prototype.forwardIn = function(bindAddr, bindPort, cb) {
                   : new Error('Unable to bind to ' + bindAddr + ':' + bindPort));
       }
 
-      if (data && data.length)
+      if (bindPort == 0 && data && data.length)
         bindPort = data.readUInt32BE(0, true);
 
       self._forwarding[bindAddr + ':' + bindPort] = true;


### PR DESCRIPTION
If I'm not passing 0, I want to use the port I sent in. At least the OSX SSH daemon is sending back a buffer that just contains 0.  This is definitely not what I want.
